### PR TITLE
removed AnkhSVN perSolution section from sln file

### DIFF
--- a/UrbanBlimp.sln
+++ b/UrbanBlimp.sln
@@ -91,8 +91,4 @@ Global
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = SmartravellerServer\SmartravellerServer.csproj
 	EndGlobalSection
-	GlobalSection(SubversionScc) = preSolution
-		Manager = AnkhSVN - Subversion Support for Visual Studio
-		Svn-Managed = True
-	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
AnkhSVN adds a preSolution section to the solution file which prevents
Visual Studio 2012.2 from using the Git Source Control

http://www.shawnmclean.com/blog/2012/08/converted-svn-to-git-project-does-not-open-in-visual-studio/
