### PR TITLE
Badge value should be sent as integer or string

### DIFF
--- a/UrbanBlimp.Tests/Apple/Push/PushServiceTests.cs
+++ b/UrbanBlimp.Tests/Apple/Push/PushServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UrbanBlimp.Apple;
@@ -54,6 +55,30 @@ namespace UrbanBlimp.Tests.Apple
                             Alert = "Alert 2"
                         }
                 };
+
+            var asyncTestHelper = new AsyncTestHelper();
+            service.Execute(pushNotification, response => asyncTestHelper.Callback(null), asyncTestHelper.HandleException);
+            asyncTestHelper.Wait();
+        }
+
+        [Test]
+        public void ToAlias()
+        {
+            var service = new PushService
+            {
+                RequestBuilder = RequestBuilderHelper.Build()
+            };
+
+            var random = new Random();
+            var pushNotification = new PushNotificationRequest
+            {
+                Aliases = new List<string>(new string[] { "1gzod" }),                
+                Payload = new PushPayload
+                {
+                    Badge = random.Next(100),
+                    Alert = "What's up iPhone",
+                }
+            };
 
             var asyncTestHelper = new AsyncTestHelper();
             service.Execute(pushNotification, response => asyncTestHelper.Callback(null), asyncTestHelper.HandleException);

--- a/UrbanBlimp/Apple/Push/BatchPushRequestSerializer.cs
+++ b/UrbanBlimp/Apple/Push/BatchPushRequestSerializer.cs
@@ -51,7 +51,18 @@ namespace UrbanBlimp.Apple
             }
             if (pushPayload.Badge != null)
             {
-                aps["badge"] = pushPayload.Badge;
+                if (pushPayload.Badge is string)
+                {
+                    aps["badge"] = pushPayload.Badge as string;
+                }
+                else if (pushPayload.Badge is int)
+                {
+                    aps["badge"] = (int)pushPayload.Badge;
+                }
+                else
+                {
+                    throw new Exception("Badge is not in valid format");
+                }
             }
             if (pushPayload.Sound != null)
             {

--- a/UrbanBlimp/Apple/Push/PushPayload.cs
+++ b/UrbanBlimp/Apple/Push/PushPayload.cs
@@ -2,7 +2,7 @@ namespace UrbanBlimp.Apple
 {
     public class PushPayload
     {
-        public string Badge;
+        public object Badge;
 
         public string Alert;
 


### PR DESCRIPTION
The UrbanAirship documentation indicates that when not using "auto,+1,-1" you should send integers in JSON and not strings. So I made a change to the payload to accept either string or int and serialize appropriately. This fixes a bug in badgeing
